### PR TITLE
Fix crash in LibraryInitializer because readdir() was not in scope.

### DIFF
--- a/Mcode/+logger/+internal/LibraryInitializer.m
+++ b/Mcode/+logger/+internal/LibraryInitializer.m
@@ -60,13 +60,12 @@ classdef LibraryInitializer
       
     end
     
-    function out = readdir(pth)
-      d = dir(pth);
-      d(ismember({d.name}, {'.','..'})) = [];
-      out = {d.name};
-    end
-    
   end
   
 end
 
+function out = readdir(pth)
+  d = dir(pth);
+  d(ismember({d.name}, {'.','..'})) = [];
+  out = {d.name};
+end

--- a/SLF4M.prj
+++ b/SLF4M.prj
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MATLABProject xmlns="http://www.mathworks.com/MATLABProjectFile" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0"/>

--- a/resources/project/Project.xml
+++ b/resources/project/Project.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info MetadataType="distributed" />

--- a/resources/project/ProjectData.type.Info.xml
+++ b/resources/project/ProjectData.type.Info.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Name="SLF4M" />

--- a/resources/project/Root.type.Categories/FileClassCategory.type.Category.xml
+++ b/resources/project/Root.type.Categories/FileClassCategory.type.Category.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info ReadOnly="1" SingleValued="1" DataType="None" Name="Classification" />

--- a/resources/project/Root.type.Categories/FileClassCategory.type.Category/artifact.type.Label.xml
+++ b/resources/project/Root.type.Categories/FileClassCategory.type.Category/artifact.type.Label.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info ReadOnly="READ_ONLY" Name="Artifact" />

--- a/resources/project/Root.type.Categories/FileClassCategory.type.Category/convenience.type.Label.xml
+++ b/resources/project/Root.type.Categories/FileClassCategory.type.Category/convenience.type.Label.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info ReadOnly="READ_ONLY" Name="Convenience" />

--- a/resources/project/Root.type.Categories/FileClassCategory.type.Category/derived.type.Label.xml
+++ b/resources/project/Root.type.Categories/FileClassCategory.type.Category/derived.type.Label.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info ReadOnly="READ_ONLY" Name="Derived" />

--- a/resources/project/Root.type.Categories/FileClassCategory.type.Category/design.type.Label.xml
+++ b/resources/project/Root.type.Categories/FileClassCategory.type.Category/design.type.Label.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info ReadOnly="READ_ONLY" Name="Design" />

--- a/resources/project/Root.type.Categories/FileClassCategory.type.Category/none.type.Label.xml
+++ b/resources/project/Root.type.Categories/FileClassCategory.type.Category/none.type.Label.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info ReadOnly="READ_ONLY" Name="None" />

--- a/resources/project/Root.type.Categories/FileClassCategory.type.Category/other.type.Label.xml
+++ b/resources/project/Root.type.Categories/FileClassCategory.type.Category/other.type.Label.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info ReadOnly="READ_ONLY" Name="Other" />

--- a/resources/project/Root.type.Categories/FileClassCategory.type.Category/test.type.Label.xml
+++ b/resources/project/Root.type.Categories/FileClassCategory.type.Category/test.type.Label.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info ReadOnly="READ_ONLY" Name="Test" />

--- a/resources/project/Root.type.Files/.editorconfig.type.File.xml
+++ b/resources/project/Root.type.Files/.editorconfig.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/.gitignore.type.File.xml
+++ b/resources/project/Root.type.Files/.gitignore.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/CHANGES.txt.type.File.xml
+++ b/resources/project/Root.type.Files/CHANGES.txt.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/LICENSE.type.File.xml
+++ b/resources/project/Root.type.Files/LICENSE.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/Makefile.type.File.xml
+++ b/resources/project/Root.type.Files/Makefile.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/Mcode.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/+internal.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/+internal.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/+internal.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/+internal.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/+internal.type.File/LibraryInitializer.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/+internal.type.File/LibraryInitializer.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/+internal.type.File/readtext.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/+internal.type.File/readtext.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/Log4jConfigurator.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/Log4jConfigurator.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/Logger.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/Logger.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/debug.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/debug.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/debugj.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/debugj.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/error.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/error.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/errorj.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/errorj.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/globals.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/globals.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/info.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/info.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/infoj.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/infoj.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/private.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/private.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/private.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/private.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/private.type.File/loggerCallImpl.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/private.type.File/loggerCallImpl.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/private.type.File/mustBeA.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/private.type.File/mustBeA.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/private.type.File/size2str.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/private.type.File/size2str.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/trace.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/trace.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/tracej.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/tracej.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/version.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/version.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/warn.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/warn.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/warnj.m.type.File.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/+logger.type.File/warnj.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/Mcode.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/Mcode.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/README.md.type.File.xml
+++ b/resources/project/Root.type.Files/README.md.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/VERSION.type.File.xml
+++ b/resources/project/Root.type.Files/VERSION.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/compatter.type.File.xml
+++ b/resources/project/Root.type.Files/compatter.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/compatter.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/compatter.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/compatter.type.File/input-templates.type.File.xml
+++ b/resources/project/Root.type.Files/compatter.type.File/input-templates.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/compatter.type.File/input-templates.type.File/.gitkeep.type.File.xml
+++ b/resources/project/Root.type.Files/compatter.type.File/input-templates.type.File/.gitkeep.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/compatter.type.File/input-templates.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/compatter.type.File/input-templates.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+database.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+database.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+database.type.File/+jdbc.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+database.type.File/+jdbc.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+database.type.File/+jdbc.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+database.type.File/+jdbc.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+database.type.File/+jdbc.type.File/@connection.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+database.type.File/+jdbc.type.File/@connection.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+database.type.File/+jdbc.type.File/@connection.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+database.type.File/+jdbc.type.File/@connection.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+database.type.File/+jdbc.type.File/@connection.type.File/dispstr.m.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+database.type.File/+jdbc.type.File/@connection.type.File/dispstr.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/dev-tools.type.File/+database.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+database.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/+deeply.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/+deeply.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/+deeply.type.File/+nested.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/+deeply.type.File/+nested.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/+deeply.type.File/+nested.type.File/+package.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/+deeply.type.File/+nested.type.File/+package.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/+deeply.type.File/+nested.type.File/+package.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/+deeply.type.File/+nested.type.File/+package.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/+deeply.type.File/+nested.type.File/+package.type.File/a_class.m.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/+deeply.type.File/+nested.type.File/+package.type.File/a_class.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/+deeply.type.File/+nested.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/+deeply.type.File/+nested.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/+deeply.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/+deeply.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/+a.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/class_in_pkg.m.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/class_in_pkg.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/func_in_pkg.m.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/+pkg.type.File/func_in_pkg.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/dev-tools.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/dev-tools.type.File/calling_Logger_directly.m.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/calling_Logger_directly.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/dev-tools.type.File/gen_dummy_log_entries.m.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/gen_dummy_log_entries.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/dev-tools.type.File/helloWorld.m.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/helloWorld.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/dev-tools.type.File/mydate.m.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/mydate.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/dev-tools.type.File/test_log.m.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/test_log.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/dev-tools.type.File/top_level_class.m.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/top_level_class.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/dev-tools.type.File/top_level_function.m.type.File.xml
+++ b/resources/project/Root.type.Files/dev-tools.type.File/top_level_function.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/doc-project.type.File.xml
+++ b/resources/project/Root.type.Files/doc-project.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/doc-project.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/doc-project.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/doc-project.type.File/Description for File Exchange.txt.type.File.xml
+++ b/resources/project/Root.type.Files/doc-project.type.File/Description for File Exchange.txt.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/doc-project.type.File/Release Checklist.md.type.File.xml
+++ b/resources/project/Root.type.Files/doc-project.type.File/Release Checklist.md.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/docs.type.File.xml
+++ b/resources/project/Root.type.Files/docs.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/docs.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/docs.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/docs.type.File/CNAME.type.File.xml
+++ b/resources/project/Root.type.Files/docs.type.File/CNAME.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/docs.type.File/Gemfile.type.File.xml
+++ b/resources/project/Root.type.Files/docs.type.File/Gemfile.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/docs.type.File/LICENSE-apache.txt.type.File.xml
+++ b/resources/project/Root.type.Files/docs.type.File/LICENSE-apache.txt.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/docs.type.File/LICENSE-bsd.txt.type.File.xml
+++ b/resources/project/Root.type.Files/docs.type.File/LICENSE-bsd.txt.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/docs.type.File/UserGuide.md.type.File.xml
+++ b/resources/project/Root.type.Files/docs.type.File/UserGuide.md.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/docs.type.File/_config.yml.type.File.xml
+++ b/resources/project/Root.type.Files/docs.type.File/_config.yml.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/docs.type.File/images.type.File.xml
+++ b/resources/project/Root.type.Files/docs.type.File/images.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/docs.type.File/images.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/docs.type.File/images.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/docs.type.File/images.type.File/SLF4M-configurator-screenshot-scaled.png.type.File.xml
+++ b/resources/project/Root.type.Files/docs.type.File/images.type.File/SLF4M-configurator-screenshot-scaled.png.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/docs.type.File/index.md.type.File.xml
+++ b/resources/project/Root.type.Files/docs.type.File/index.md.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/java.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/java.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/java.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/java.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/java.type.File/log4j1-config-gui.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/java.type.File/log4j1-config-gui.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/java.type.File/log4j1-config-gui.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/java.type.File/log4j1-config-gui.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/java.type.File/log4j1-config-gui.type.File/README.md.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/java.type.File/log4j1-config-gui.type.File/README.md.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/java.type.File/log4j1-config-gui.type.File/log4j1-config-gui-0.1.1.jar.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/java.type.File/log4j1-config-gui.type.File/log4j1-config-gui-0.1.1.jar.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/LICENSE.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/LICENSE.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode-examples.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode-examples.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode-examples.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode-examples.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode-examples.type.File/Birthday.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode-examples.type.File/Birthday.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode-examples.type.File/UserID.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode-examples.type.File/UserID.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/convertArgsForPrintf.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/convertArgsForPrintf.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/dispc.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/dispc.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/isErrorIdentifier.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/isErrorIdentifier.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/mycombvec.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/mycombvec.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/num2cellstr.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/num2cellstr.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/prettyprint_array.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/prettyprint_array.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/prettyprint_cell.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/prettyprint_cell.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/prettyprint_struct.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/prettyprint_struct.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/prettyprint_tabular.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/prettyprint_tabular.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/size2str.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/size2str.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/sprintfv.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/+internal.type.File/sprintfv.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/Displayable.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/Displayable.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/DisplayableHandle.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/DisplayableHandle.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/DispstrHelper.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/+dispstrlib.type.File/DispstrHelper.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/dispstr.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/dispstr.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/dispstrs.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/dispstrs.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/errords.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/errords.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/fprintfds.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/fprintfds.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/pp.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/pp.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/prettyprint.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/prettyprint.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/private.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/private.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/private.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/private.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/private.type.File/cellrec.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/private.type.File/cellrec.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/private.type.File/cellrec2struct.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/private.type.File/cellrec2struct.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/private.type.File/copyfields.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/private.type.File/copyfields.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/private.type.File/parseOpts.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/private.type.File/parseOpts.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/sprintfds.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/sprintfds.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/warningds.m.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/Mcode.type.File/warningds.m.type.File.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design" />
+    </Category>
+</Info>

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/README.md.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/README.md.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/VERSION.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/VERSION.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/doc.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/doc.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/doc.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/doc.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/doc.type.File/Changelog.md.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/doc.type.File/Changelog.md.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/doc.type.File/Developer-Notes.md.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/doc.type.File/Developer-Notes.md.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/doc.type.File/Index.md.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/doc.type.File/Index.md.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/doc.type.File/Text for File Exchange.txt.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/doc.type.File/Text for File Exchange.txt.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/doc.type.File/User-Guide.md.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/matlab.type.File/dispstr.type.File/dispstr-1.1.1.type.File/doc.type.File/User-Guide.md.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/shims.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/shims.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/shims.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/shims.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File/java.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File/java.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File/java.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File/java.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File/java.type.File/slf4j-1.5.8.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File/java.type.File/slf4j-1.5.8.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File/java.type.File/slf4j-1.5.8.type.File/1.type.DIR_SIGNIFIER.xml
+++ b/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File/java.type.File/slf4j-1.5.8.type.File/1.type.DIR_SIGNIFIER.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File/java.type.File/slf4j-1.5.8.type.File/slf4j-api-1.5.8.jar.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File/java.type.File/slf4j-1.5.8.type.File/slf4j-api-1.5.8.jar.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File/java.type.File/slf4j-1.5.8.type.File/slf4j-log4j12-1.5.8.jar.type.File.xml
+++ b/resources/project/Root.type.Files/lib.type.File/shims.type.File/eq.type.File/R2020a.type.File/java.type.File/slf4j-1.5.8.type.File/slf4j-log4j12-1.5.8.jar.type.File.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />

--- a/resources/project/Root.type.ProjectPath/0aa08270-0ed5-406d-81d8-e4638427d2eb.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/0aa08270-0ed5-406d-81d8-e4638427d2eb.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="lib/shims" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/1624ace7-14a8-48d0-9bc9-ec17a9081927.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/1624ace7-14a8-48d0-9bc9-ec17a9081927.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="lib/matlab/dispstr/dispstr-1.1.1/doc" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/1add4901-cba8-470a-8afc-a1cc7f2fa4e6.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/1add4901-cba8-470a-8afc-a1cc7f2fa4e6.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="lib/matlab/dispstr/dispstr-1.1.1/Mcode-examples" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/2428d1aa-4303-43f5-a145-7b4281fb4902.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/2428d1aa-4303-43f5-a145-7b4281fb4902.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="docs/images" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/2da380df-27cd-427d-aba3-c990a1224559.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/2da380df-27cd-427d-aba3-c990a1224559.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="lib/shims/eq/R2020a/java/slf4j-1.5.8" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/31e01358-ddad-4fcf-842c-967ba02b66e1.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/31e01358-ddad-4fcf-842c-967ba02b66e1.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="dev-tools" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/3334e5ef-82b2-4bfa-b6e1-80e7ac0791cc.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/3334e5ef-82b2-4bfa-b6e1-80e7ac0791cc.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="lib/matlab" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/43c0ddcb-6514-498b-85f1-407dbc2ef663.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/43c0ddcb-6514-498b-85f1-407dbc2ef663.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="lib/java/log4j1-config-gui" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/4aab83e2-f779-4e9b-ad35-a6dd9dc8e4cc.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/4aab83e2-f779-4e9b-ad35-a6dd9dc8e4cc.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="docs" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/52dec5cd-5320-47ee-8eb0-ca31c1274834.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/52dec5cd-5320-47ee-8eb0-ca31c1274834.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="Mcode" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/6777aeb9-a401-4f91-b8cf-ef13a41660ce.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/6777aeb9-a401-4f91-b8cf-ef13a41660ce.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="lib/matlab/dispstr" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/6b2289d2-4e59-47c3-8043-f54d18562a52.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/6b2289d2-4e59-47c3-8043-f54d18562a52.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="lib/shims/eq/R2020a/java" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/7f0dee22-711a-41c7-af11-98fb8db53584.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/7f0dee22-711a-41c7-af11-98fb8db53584.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="lib/matlab/dispstr/dispstr-1.1.1/Mcode" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/8082514f-f4e8-4d65-9d0f-2a09d1d216ba.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/8082514f-f4e8-4d65-9d0f-2a09d1d216ba.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="lib/shims/eq" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/98b7c7b3-9bff-4360-8c92-52381316a722.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/98b7c7b3-9bff-4360-8c92-52381316a722.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="lib/matlab/dispstr/dispstr-1.1.1" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/9f9c0fb4-02fc-4a07-a2ca-236dd885c04f.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/9f9c0fb4-02fc-4a07-a2ca-236dd885c04f.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="compatter" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/a0b2bc95-260c-43e0-a306-54335f1fc45a.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/a0b2bc95-260c-43e0-a306-54335f1fc45a.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="lib/java" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/b1c61536-c676-44d5-ad24-ba140386f578.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/b1c61536-c676-44d5-ad24-ba140386f578.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="lib/shims/eq/R2020a" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/eec7babc-1f5d-4c7d-b3d1-8e1cd2f23be6.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/eec7babc-1f5d-4c7d-b3d1-8e1cd2f23be6.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="lib" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/f40b434f-7b12-4954-a2a2-9eeac36ba1de.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/f40b434f-7b12-4954-a2a2-9eeac36ba1de.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="doc-project" Type="Relative" />

--- a/resources/project/Root.type.ProjectPath/f682763a-4091-46d5-aef1-d0b35a5fb63c.type.Reference.xml
+++ b/resources/project/Root.type.ProjectPath/f682763a-4091-46d5-aef1-d0b35a5fb63c.type.Reference.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info Ref="compatter/input-templates" Type="Relative" />

--- a/resources/project/uuid-237589a5-bfea-481f-b867-17fb19069feb.xml
+++ b/resources/project/uuid-237589a5-bfea-481f-b867-17fb19069feb.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Info />


### PR DESCRIPTION
Fix problem in class LibraryInitializer where function readdir() was defined as a static method. Needs to be either defined as a local function, or called with a fully qualified name, ie logger.internal.LibraryInitializer.readdir(). I chose local function.

Tested with helloWorld.m and test_log.m. Now appears to be working correctly.