### PR TITLE
function shims and name fix for R2015b

### DIFF
--- a/Mcode/+logger/Log4jConfigurator.m
+++ b/Mcode/+logger/Log4jConfigurator.m
@@ -114,9 +114,9 @@ classdef Log4jConfigurator
             %     });
             for i = 1:size(levels, 1)
                 [logName,levelName] = levels{i,:};
-                logger = org.apache.log4j.LogManager.getLogger(logName);
+                loggerobj = org.apache.log4j.LogManager.getLogger(logName);
                 level = logger.Log4jConfigurator.getLog4jLevel(levelName);
-                logger.setLevel(level);
+                loggerobj.setLevel(level);
             end
         end
         

--- a/Mcode/+logger/Log4jConfigurator.m
+++ b/Mcode/+logger/Log4jConfigurator.m
@@ -114,9 +114,9 @@ classdef Log4jConfigurator
             %     });
             for i = 1:size(levels, 1)
                 [logName,levelName] = levels{i,:};
-                loggerobj = org.apache.log4j.LogManager.getLogger(logName);
+                loggerObj = org.apache.log4j.LogManager.getLogger(logName);
                 level = logger.Log4jConfigurator.getLog4jLevel(levelName);
-                loggerobj.setLevel(level);
+                loggerObj.setLevel(level);
             end
         end
         

--- a/lib/shims/eq/R2015b/@char/string.m
+++ b/lib/shims/eq/R2015b/@char/string.m
@@ -1,0 +1,17 @@
+function out = string(varargin)
+%STRING Create character array (string). (custom implementation)
+%   This implementation supports using older MATLAB to execute some code
+%   that relies on the function that was introduced in newer MATLAB.
+%   For its purpose, this implementation does not need to be completely
+%   faithful to the MathWorks implementation, and may not be suitable as
+%   a general replacement.
+%
+%   R2015b STRING is a built-in method and throws an exception,
+%       Error using string
+%       string is obsolete and will be discontinued. Use char instead.
+%   MathWorks new STRING (String array) was introduced in R2016b.
+%   https://www.mathworks.com/help/matlab/ref/string.html
+
+out = char(varargin{:});
+
+end

--- a/lib/shims/eq/R2015b/contains.m
+++ b/lib/shims/eq/R2015b/contains.m
@@ -1,9 +1,14 @@
-function result = contains(str, pat)
+function out = contains(str, pat)
+%CONTAINS Determine if pattern is in strings (custom implementation)
+%   This implementation supports using older MATLAB to execute some code
+%   that relies on the function that was introduced in newer MATLAB.
+%   For its purpose, this implementation does not need to be completely
+%   faithful to the MathWorks implementation, and may not be suitable as
+%   a general replacement.
+%
+%   MathWorks CONTAINS was introduced in R2016b.
+%   https://www.mathworks.com/help/matlab/ref/contains.html
 
-% CONTAINS Determine if pattern is in strings
-% CONTAINS Introduced in R2016b
-% https://www.mathworks.com/help/matlab/ref/contains.html
+out = ~isempty(strfind(str, pat));
 
-result = length(strfind(str, pat)) > 0;
-
-end  % function contains
+end

--- a/lib/shims/eq/R2015b/contains.m
+++ b/lib/shims/eq/R2015b/contains.m
@@ -1,0 +1,9 @@
+function result = contains(str, pat)
+
+% CONTAINS Determine if pattern is in strings
+% CONTAINS Introduced in R2016b
+% https://www.mathworks.com/help/matlab/ref/contains.html
+
+result = length(strfind(str, pat)) > 0;
+
+end  % function contains

--- a/lib/shims/eq/R2015b/isfolder.m
+++ b/lib/shims/eq/R2015b/isfolder.m
@@ -1,0 +1,9 @@
+function result = isfolder(folderName)
+
+% ISFOLDER Introduced in R2017b
+% ISFOLDER Determine if input is folder
+% https://www.mathworks.com/help/matlab/ref/isfolder.html
+
+result = isdir(folderName);
+
+end  % function isfolder

--- a/lib/shims/eq/R2015b/isfolder.m
+++ b/lib/shims/eq/R2015b/isfolder.m
@@ -1,9 +1,14 @@
-function result = isfolder(folderName)
+function out = isfolder(folderName)
+%ISFOLDER Determine if input is folder (custom implementation)
+%   This implementation supports using older MATLAB to execute some code
+%   that relies on the function that was introduced in newer MATLAB.
+%   For its purpose, this implementation does not need to be completely
+%   faithful to the MathWorks implementation, and may not be suitable as
+%   a general replacement.
+%
+%   MathWorks ISFOLDER was introduced in R2017b.
+%   https://www.mathworks.com/help/matlab/ref/isfolder.html
 
-% ISFOLDER Introduced in R2017b
-% ISFOLDER Determine if input is folder
-% https://www.mathworks.com/help/matlab/ref/isfolder.html
+out = isdir(folderName);
 
-result = isdir(folderName);
-
-end  % function isfolder
+end

--- a/lib/shims/eq/R2015b/newline.m
+++ b/lib/shims/eq/R2015b/newline.m
@@ -1,9 +1,20 @@
-function result = newline
+function out = newline
+%NEWLINE Create newline character (custom implementation)
+%   This implementation supports using older MATLAB to execute some code
+%   that relies on the function that was introduced in newer MATLAB.
+%   For its purpose, this implementation does not need to be completely
+%   faithful to the MathWorks implementation, and may not be suitable as
+%   a general replacement.
+%
+%   MathWorks NEWLINE was introduced in R2016b.
+%   https://www.mathworks.com/help/matlab/ref/newline.html
 
-% NEWLINE Create newline character
-% NEWLINE Introduced in R2016b
-% https://www.mathworks.com/help/matlab/ref/newline.html
+persistent val
 
-result = sprintf('\n');
+if isempty(val)
+    val = sprintf('\n');
+end
 
-end  % function newline
+out = val;
+
+end

--- a/lib/shims/eq/R2015b/newline.m
+++ b/lib/shims/eq/R2015b/newline.m
@@ -1,0 +1,9 @@
+function result = newline
+
+% NEWLINE Create newline character
+% NEWLINE Introduced in R2016b
+% https://www.mathworks.com/help/matlab/ref/newline.html
+
+result = sprintf('\n');
+
+end  % function newline


### PR DESCRIPTION
Four m-files for functions that are not yet implemented as of 2015b.  The shims dir that I've parked them in is not on the matlabpath, so to use this SLF4M library in R2015b, in addition to this:
    addpath(fullfile(pwd, 'SLF4M/Mcode'))
I also do this:
    addpath(fullfile(pwd, 'SLF4M/lib/shims/eq/R2015b'))

Of course I thought about putting the extra addpath in the package itself, and further, making those three private to the SLF4M and only in play when using R2015b, but, I just didn't get there yet.

Also the 2-line change to Log4jConfigurator.m was needed (at least in 2015b, but probably for all?) for the setLevels to work instead of error.