### PR TITLE
Handle exceptions raised during log message formatting

### DIFF
--- a/Mcode/+logger/Logger.m
+++ b/Mcode/+logger/Logger.m
@@ -106,8 +106,14 @@ classdef Logger
       if ~this.jLogger.isErrorEnabled()
         return
       end
-      msgStr = formatMessage(msg, varargin{:});
-      this.jLogger.error(msgStr);
+      try
+        msgStr = formatMessage(msg, varargin{:});
+        this.jLogger.error(msgStr);
+      catch ME
+        if logger.raiseExceptions
+          throw(ME)
+        end
+      end
     end
     
     function warn(this, msg, varargin)
@@ -115,8 +121,14 @@ classdef Logger
       if ~this.jLogger.isWarnEnabled()
         return
       end
-      msgStr = formatMessage(msg, varargin{:});
-      this.jLogger.warn(msgStr);
+      try
+        msgStr = formatMessage(msg, varargin{:});
+        this.jLogger.warn(msgStr);
+      catch ME
+        if logger.raiseExceptions
+          throw(ME)
+        end
+      end
     end
     
     function info(this, msg, varargin)
@@ -124,8 +136,14 @@ classdef Logger
       if ~this.jLogger.isInfoEnabled()
         return
       end
-      msgStr = formatMessage(msg, varargin{:});
-      this.jLogger.info(msgStr);
+      try
+        msgStr = formatMessage(msg, varargin{:});
+        this.jLogger.info(msgStr);
+      catch ME
+        if logger.raiseExceptions
+          throw(ME)
+        end
+      end
     end
     
     function debug(this, msg, varargin)
@@ -133,8 +151,14 @@ classdef Logger
       if ~this.jLogger.isDebugEnabled()
         return
       end
-      msgStr = formatMessage(msg, varargin{:});
-      this.jLogger.debug(msgStr);
+      try
+        msgStr = formatMessage(msg, varargin{:});
+        this.jLogger.debug(msgStr);
+      catch ME
+        if logger.raiseExceptions
+          throw(ME)
+        end
+      end
     end
     
     function trace(this, msg, varargin)
@@ -142,8 +166,14 @@ classdef Logger
       if ~this.jLogger.isTraceEnabled()
         return
       end
-      msgStr = formatMessage(msg, varargin{:});
-      this.jLogger.trace(msgStr);
+      try
+        msgStr = formatMessage(msg, varargin{:});
+        this.jLogger.trace(msgStr);
+      catch ME
+        if logger.raiseExceptions
+          throw(ME)
+        end
+      end
     end
     
     function errorj(this, msg, varargin)

--- a/Mcode/+logger/raiseExceptions.m
+++ b/Mcode/+logger/raiseExceptions.m
@@ -1,0 +1,46 @@
+function varargout = raiseExceptions(newval)
+%RAISEEXCEPTIONS gets/sets a flag for handling exceptions during logging
+%   RAISEEXCEPTIONS gets or sets a flag that is used by the logic that
+%   controls the handling of exceptions raised/thrown during logging.
+%   The default flag value is true.
+%
+%   Usage
+%       % suppress exceptions during logging framework message handling
+%       logger.raiseExceptions(false)
+
+%{
+This mechanism is inspired by a comment from Martijn Pieters in
+https://stackoverflow.com/questions/66587941/what-happens-if-a-python-logging-handler-raises-an-exception
+
+"The Python standard-library handlers have been build with robustness in 
+mind.  If an exception is raised ..., all standard library 
+implementations catch the exception and ...
+By default, ... re-raises the exception.  In production systems you want 
+to set logging.raiseExceptions = False, at which point the exceptions 
+are silently ignored, and logging continues as if nothing happened.
+
+From the documentation: ... If the module-level attribute 
+raiseExceptions is False, exceptions get silently ignored. This is what 
+is mostly wanted for a logging system - most users will not care about 
+errors in the logging system, they are more interested in application 
+errors.  ... (The default value of raiseExceptions is True, as that is 
+more useful during development)."
+%}
+
+persistent flag
+
+if isempty(flag)
+    flag = true;
+end
+
+switch nargin
+    case 0  % get
+        varargout{1} = flag;
+    case 1  % set
+        assert(isscalar(newval) & islogical(newval), 'bad usage')
+        flag = newval;
+    otherwise
+        assert(false, 'impossible')
+end
+
+end

--- a/Mcode/+logger/throwExceptions.m
+++ b/Mcode/+logger/throwExceptions.m
@@ -1,0 +1,12 @@
+function varargout = throwExceptions(varargin)
+%THROWEXCEPTIONS is an alias for RAISEEXCEPTIONS
+%   RAISEEXCEPTIONS is inspired by the Python standard library
+%   framework.
+%   In MATLAB, exceptions are 'thrown' rather than 'raised', so 
+%   THROWEXCEPTIONS is provided as a more MATLAB-consistent alias. 
+%
+%   Usage
+%       % suppress exceptions during logging framework message handling
+%       logger.throwExceptions(false)
+
+[varargout{1:nargout}] = logger.raiseExceptions(varargin{:});


### PR DESCRIPTION
Motivation -- see https://stackoverflow.com/questions/66587941/what-happens-if-a-python-logging-handler-raises-an-exception
Offering a way to de-risk the lazy eval could increase acceptance.

If the package attribute raiseExceptions is False, exceptions get silently ignored. This is what is mostly wanted for a logging system - most users will not care about errors in the logging system, they are more interested in application errors.  ... (The default value of raiseExceptions is True, as that is more useful during development).

This is implemented by
1. new package function raiseExceptions which keeps a persistent flag value (default true)
2. new package function throwExceptions which provides an alias for raiseExceptions
3. in five +logger/Logger methods, I wrapped the lazy eval in a try/catch.